### PR TITLE
Add simple OCR script for captcha digits

### DIFF
--- a/ocr_persian.py
+++ b/ocr_persian.py
@@ -1,0 +1,30 @@
+import pytesseract
+from pathlib import Path
+
+CAPTCHA_DIR = Path('captchas')
+WHITELIST = '0123456789'
+
+
+def ocr_image(path: Path) -> str:
+    config = f'--psm 7 -c tessedit_char_whitelist={WHITELIST}'
+    text = pytesseract.image_to_string(str(path), lang='eng', config=config)
+    digits = ''.join(ch for ch in text if ch in WHITELIST)
+    return digits
+
+
+def main():
+    results = {}
+    for file in sorted(CAPTCHA_DIR.glob('*.gif')):
+        digits = ocr_image(file)
+        results[file.name] = digits
+        print(f'{file.name}: {digits}')
+
+    out_path = Path('out.txt')
+    with open(out_path, 'w', encoding='utf-8') as f:
+        for name, digits in results.items():
+            f.write(f'{name}\t{digits}\n')
+    print(f'written results to {out_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/out.txt
+++ b/out.txt
@@ -1,1 +1,100 @@
-
+captcha_001.gif	9
+captcha_002.gif	99158989
+captcha_003.gif	99
+captcha_004.gif	
+captcha_005.gif	93919
+captcha_006.gif	9
+captcha_007.gif	
+captcha_008.gif	999
+captcha_009.gif	95
+captcha_010.gif	5
+captcha_011.gif	9
+captcha_012.gif	908910529
+captcha_013.gif	9954
+captcha_014.gif	2915
+captcha_015.gif	
+captcha_016.gif	5
+captcha_017.gif	29399
+captcha_018.gif	9
+captcha_019.gif	9953999
+captcha_020.gif	9959
+captcha_021.gif	
+captcha_022.gif	
+captcha_023.gif	9
+captcha_024.gif	9999386
+captcha_025.gif	9918
+captcha_026.gif	91
+captcha_027.gif	990
+captcha_028.gif	
+captcha_029.gif	9
+captcha_030.gif	
+captcha_031.gif	
+captcha_032.gif	
+captcha_033.gif	
+captcha_034.gif	
+captcha_035.gif	992
+captcha_036.gif	
+captcha_037.gif	
+captcha_038.gif	
+captcha_039.gif	
+captcha_040.gif	98910999
+captcha_041.gif	8595159292
+captcha_042.gif	922915839993
+captcha_043.gif	
+captcha_044.gif	9955
+captcha_045.gif	98999
+captcha_046.gif	0151999
+captcha_047.gif	5996
+captcha_048.gif	29879931506
+captcha_049.gif	92999579393
+captcha_050.gif	99110939
+captcha_051.gif	803
+captcha_052.gif	2
+captcha_053.gif	
+captcha_054.gif	29
+captcha_055.gif	999
+captcha_056.gif	999993
+captcha_057.gif	99
+captcha_058.gif	855
+captcha_059.gif	9150905393
+captcha_060.gif	9135
+captcha_061.gif	99
+captcha_062.gif	91
+captcha_063.gif	95991995
+captcha_064.gif	
+captcha_065.gif	
+captcha_066.gif	95299
+captcha_067.gif	
+captcha_068.gif	99
+captcha_069.gif	
+captcha_070.gif	59
+captcha_071.gif	
+captcha_072.gif	
+captcha_073.gif	9292949
+captcha_074.gif	9
+captcha_075.gif	2955399
+captcha_076.gif	
+captcha_077.gif	599
+captcha_078.gif	790
+captcha_079.gif	
+captcha_080.gif	8
+captcha_081.gif	
+captcha_082.gif	
+captcha_083.gif	
+captcha_084.gif	
+captcha_085.gif	9
+captcha_086.gif	99
+captcha_087.gif	529
+captcha_088.gif	039295999937
+captcha_089.gif	99
+captcha_090.gif	
+captcha_091.gif	
+captcha_092.gif	
+captcha_093.gif	9
+captcha_094.gif	9
+captcha_095.gif	
+captcha_096.gif	
+captcha_097.gif	5
+captcha_098.gif	52292
+captcha_099.gif	999
+captcha_100.gif	907995


### PR DESCRIPTION
## Summary
- add `ocr_persian.py` script using pytesseract
- store example OCR outputs in `out.txt`

## Testing
- `python ocr_persian.py | head`

------
https://chatgpt.com/codex/tasks/task_e_68485c6600a0832883f461bf1652f587